### PR TITLE
Corrected spelling mistake in Readme heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# django-intertia-demo
+# django-inertia-demo
 
 [![Build Status](https://travis-ci.org/zodman/django-inertia-demo.svg?branch=master)](https://travis-ci.org/zodman/django-inertia-demo)
 


### PR DESCRIPTION
I'm pretty sure the heading should be "django-inertia-demo" not "django-intertia-demo" in the Readme file.